### PR TITLE
Fix typographical errors and use system swift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 BUILD_CONFIGURATION ?= debug
 
 # Commonly used locations
-SWIFT := "/usr/bin/swift"
+SWIFT ?= $(shell command -v swift)
 ROOT_DIR := $(shell git rev-parse --show-toplevel)
 BUILD_BIN_DIR := $(shell $(SWIFT) build -c $(BUILD_CONFIGURATION) --show-bin-path)
 

--- a/Sources/Containerization/Image/Image.swift
+++ b/Sources/Containerization/Image/Image.swift
@@ -115,8 +115,8 @@ public struct Image: Sendable {
         for manifest in index.manifests {
             referenced.append(manifest.digest.trimmingDigestPrefix)
             guard let m: Manifest = try? await contentStore.get(digest: manifest.digest) else {
-                // If the requested digest does not exist or is not a manifest. Skip.
-                // Its safe to skip processing this digest as it wont have any child layers.
+                // If the requested digest does not exist or is not a manifest, skip.
+                // It's safe to skip processing this digest as it won't have any child layers.
                 continue
             }
             let descs = m.layers + [m.config]

--- a/Sources/ContainerizationEXT4/EXT4+Format.swift
+++ b/Sources/ContainerizationEXT4/EXT4+Format.swift
@@ -629,7 +629,7 @@ extension EXT4 {
             var diskSize = dataSize
             var minimumDiskSize = (blockGroupSize.blockGroups - 1) * self.blocksPerGroup + 1
             if blockGroupSize.blockGroups == 1 {
-                minimumDiskSize = self.blocksPerGroup  // atleast 1 block group
+                minimumDiskSize = self.blocksPerGroup  // at least 1 block group
             }
             if diskSize < minimumDiskSize {  // for data + metadata
                 diskSize = minimumDiskSize

--- a/Sources/ContainerizationOCI/Platform.swift
+++ b/Sources/ContainerizationOCI/Platform.swift
@@ -263,7 +263,7 @@ extension Platform: Hashable {
         //  then, there is a possibility that for arm64 architecture, the variant may be set to nil
         //  In that case, the variant should be assumed to v8
         if lhs.architecture == "arm64" && rhs.architecture == "arm64" {
-            // The following checks effictively verify
+            // The following checks effectively verify
             // that one operand has nil value and other has "v8"
             if lhs.variant == nil || rhs.variant == nil {
                 if lhs.variant == "v8" || rhs.variant == "v8" {

--- a/Sources/ContainerizationOS/Command.swift
+++ b/Sources/ContainerizationOS/Command.swift
@@ -242,7 +242,7 @@ extension Command {
 
     /// Create a posix_spawn file actions set of fds to pass to the new process
     private func createFileset() throws -> (null: FileHandle, handles: [FileHandle]) {
-        // grab dev null incase a handle passed by the user is nil
+        // grab dev null in case a handle passed by the user is nil
         let null = try openDevNull()
         var files = [FileHandle]()
         files.append(stdin ?? null)

--- a/Tests/ContainerizationOCITests/RegistryClientTests.swift
+++ b/Tests/ContainerizationOCITests/RegistryClientTests.swift
@@ -294,7 +294,7 @@ struct OCIClientTests: ~Copyable {
             )
         )
         do {
-            _ = try await client.resolve(name: "conatinerization/not-exists", tag: "foo")
+            _ = try await client.resolve(name: "containerization/not-exists", tag: "foo")
         } catch {
             #expect(counter.withLock { $0 } <= 3)
         }

--- a/scripts/make-docs.sh
+++ b/scripts/make-docs.sh
@@ -39,6 +39,6 @@ if [ ! -z "$2" ] ; then
     opts+=("--hosting-base-path" "$2")
 fi
 
-/usr/bin/swift package ${opts[@]}
+"$(command -v swift)" package "${opts[@]}"
 
 echo '{}' > "$1/theme-settings.json"


### PR DESCRIPTION
## Summary
- clean up comments and tests
- fix typographical mistakes across sources
- make `swift` path configurable

## Testing
- `make swift-fmt`
- `make test` *(fails: cannot compile ContainerizationOS due to missing system headers)*

------
https://chatgpt.com/codex/tasks/task_e_6849bad746548326bc9bdabe84221fb0